### PR TITLE
Another config update for repo move

### DIFF
--- a/data/tester.jsonld
+++ b/data/tester.jsonld
@@ -1,12 +1,12 @@
 {
   "@context": "https://www.w3.org/ns/solid/oidc-context.jsonld",
 
-  "client_id": "https://solid.github.io/solid-oidc-tests/data/tester.jsonld",
-  "redirect_uris": ["https://solid.github.io/solid-oidc-tests/callback.html"],
+  "client_id": "https://inrupt.github.io/solid-oidc-tests/data/tester.jsonld",
+  "redirect_uris": ["https://inrupt.github.io/solid-oidc-tests/callback.html"],
   "client_name": "Solid-OIDC Tester",
-  "logo_uri": "https://solid.github.io/solid-oidc-tests/img/solid.svg",
+  "logo_uri": "https://inrupt.github.io/solid-oidc-tests/img/solid.svg",
   "contacts": ["https://id.inrupt.com/acoburn"],
-  "client_uri": "https://solid.github.io/solid-oidc-tests/",
+  "client_uri": "https://inrupt.github.io/solid-oidc-tests/",
   "grant_types": ["authorization_code"],
   "response_types": ["code"]
 }


### PR DESCRIPTION
Left out of https://github.com/inrupt/solid-oidc-tests/pull/4.